### PR TITLE
Add software development page and site-wide improvements

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="NelePC on tamperelainen kahden veljeksen IT-yritys. Palvelemme yrityksiä ja yksityisasiakkaita laitehankinnoissa, ohjelmistokehityksessä ja IT-tuessa koko Pirkanmaalla.">
     <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
-	<title>NelePC</title>
+	<title>NelePC – Tietoa meistä</title>
 	<link rel="stylesheet" href="styles/aboutus.css">
+	<link rel="stylesheet" href="styles/footer.css">
 	<script src="helpers/common.js" defer></script>
 	<script src="helpers/staticPhotos.js" defer></script>
 </head>
@@ -17,6 +19,7 @@
             <a href="index.html">Etusivu</a>
             <a href="devices.html">Laitteet</a>
             <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
             <a href="aboutus.html">Tietoa meistä</a>
             <!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
@@ -35,5 +38,30 @@
 				<p>Voit ottaa meihin yhteyttä puhelimitse, sähköpostilla tai yhteydenottolomakkeella. Autamme mielellämme!</p>
 			</div>
 		</div>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
 </body>
 </html>

--- a/consumer.html
+++ b/consumer.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="Käyttövalmiit tietokoneet, oheislaitteet ja tarkistetut käytetyt laitteet kuluttajille. Pelikoneet, kannettavat ja paljon muuta – NelePC, Tampere.">
     <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
-	<title>NelePC</title>
+	<title>NelePC – Kuluttajat</title>
 	<link rel="stylesheet" href="styles/consumer.css">
-    
+	<link rel="stylesheet" href="styles/footer.css">
 	<style>
 		.contact-link {
 			color: inherit;
@@ -53,6 +54,7 @@
             <a href="index.html">Etusivu</a>
             <a href="devices.html">Laitteet</a>
             <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
             <a href="aboutus.html">Tietoa meistä</a>
             <!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
@@ -67,6 +69,31 @@
 					<p>Tarkistetut ja toimintavarmat käytetyt laitteet fiksuun hintaan. Käytetty tietokone, kannettava tai oheislaite on edullinen ja vastuullinen valinta, joka sopii monenlaisiin tarpeisiin.</p>
 					<h4><a href="contactus.html" class="contact-link">Ota yhteyttä</a> niin autamme löytämään sinulle sopivan laitteen.</h4>
 			</div>
-		</div>  
+		</div>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
 </body>
 </html>

--- a/contactus.html
+++ b/contactus.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="Ota yhteyttä NelePC:lle puhelimitse, sähköpostilla tai lomakkeella. Autamme laitehankinnoissa, ohjelmistokehityksessä ja kaikissa IT-asioissa.">
     <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
-	<title>NelePC</title>
+	<title>NelePC – Ota yhteyttä</title>
 	<link rel="stylesheet" href="styles/contactus.css">
+	<link rel="stylesheet" href="styles/footer.css">
 	<script src="helpers/common.js" defer></script>
     <script src="helpers/staticPhotos.js" defer></script>
 </head>
@@ -17,6 +19,7 @@
             <a href="index.html">Etusivu</a>
             <a href="devices.html">Laitteet</a>
             <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
             <a href="aboutus.html">Tietoa meistä</a>
             <!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
@@ -43,5 +46,30 @@
             </form>
         </div>
     </div>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
 </body>
 </html>

--- a/devices.html
+++ b/devices.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="Laadukkaat yritystietokoneet, kannettavat, puhelimet ja AV-laitteet kilpailukykyiseen hintaan. Toimitus ja käyttöönotto avaimet käteen – NelePC, Tampere.">
     <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
-	<title>NelePC</title>
+	<title>NelePC – Laitteet</title>
 	<link rel="stylesheet" href="styles/devices.css">
+	<link rel="stylesheet" href="styles/footer.css">
 	<style>
 		.contact-link {
 			color: inherit;
@@ -52,6 +54,7 @@
             <a href="index.html">Etusivu</a>
             <a href="devices.html">Laitteet</a>
             <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
             <a href="aboutus.html">Tietoa meistä</a>
             <!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
@@ -75,6 +78,31 @@
 				<h4>Tarjoamme joustavat hankintatavat, jotka mukautuvat yrityksesi tilanteeseen. Laitteet voidaan hankkia ostolaskulla, leasing-sopimuksella tai rahoituksen kautta, juuri teille sopivalla tavalla. Tarjoamme aina selkeän kokonaisuuden, joka on teille järkevä, käytännöllinen ja aidosti toimiva ratkaisu.</h4>
 				<h4><a href="contactus.html" class="contact-link">Ota yhteyttä</a> niin hoidetaan yhdessä kaikki yrityksesi IT-laitteet kerrasta kuntoon.</h4>
 			</div>
-		</div>  
-	</body>
+		</div>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
+</body>
 </html>

--- a/helpers/common.js
+++ b/helpers/common.js
@@ -4,6 +4,13 @@ document.addEventListener('DOMContentLoaded', function() {
     menuToggle.addEventListener('click', function() {
         nav.classList.toggle('open');
     });
+
+    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+    document.querySelectorAll('nav a').forEach(link => {
+        if (link.getAttribute('href') === currentPage) {
+            link.classList.add('active');
+        }
+    });
 });
 
 window.addEventListener('resize', function() {

--- a/helpers/staticPhotos.js
+++ b/helpers/staticPhotos.js
@@ -13,7 +13,8 @@ const pageBackgrounds = {
   'devices.html': '../assets/työpöytä2-1920.jpg',
   'consumer.html': '../assets/Cyberpunk-pelitietokone.jpg',
   'aboutus.html': '../assets/job-5382501.jpg',
-  'contactus.html': '../assets/läppäri2-1920.jpg'
+  'contactus.html': '../assets/läppäri2-1920.jpg',
+  'softwaredevelopment.html': '../assets/notebook-2386034.jpg'
 };
 
 // Auto-detect current page and set appropriate background

--- a/index.html
+++ b/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="NelePC – tamperelainen IT-yritys. Laitehankinnat, ohjelmistokehitys ja IT-tuki yrityksille ja kuluttajille koko Pirkanmaalla.">
     <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
-	<title>NelePC</title>
+	<title>NelePC – IT-ratkaisut Pirkanmaalla</title>
 	<link rel="stylesheet" href="styles/index.css">
+	<link rel="stylesheet" href="styles/footer.css">
 	<script src="helpers/dynamicPhotos.js" defer></script>
 	<script src="helpers/common.js" defer></script>
 </head>
@@ -17,16 +19,66 @@
             <a href="index.html">Etusivu</a>
             <a href="devices.html">Laitteet</a>
             <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
             <a href="aboutus.html">Tietoa meistä</a>
             <!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
         </nav>
     </header>
-		<div class="hero">
-			<div class="hero-text">
-				<h1>Tervetuloa NelePC:lle</h1>
-				<p>Laadukkaat IT-ratkaisut yrityksille ja yksityisasiakkaille</p>
+
+	<div class="hero">
+		<div class="hero-text">
+			<h1>Tervetuloa NelePC:lle</h1>
+			<p>Laadukkaat IT-ratkaisut yrityksille ja yksityisasiakkaille</p>
+		</div>
+	</div>
+
+	<section class="services-preview">
+		<div class="services-preview-inner">
+			<h2>Mitä tarjoamme</h2>
+			<div class="preview-cards">
+				<a href="devices.html" class="preview-card">
+					<h3>Laitteet</h3>
+					<p>Tietokoneet, kannettavat ja oheislaitteet yrityksille. Toimitetaan esiasennettuina ja käyttövalmiina.</p>
+				</a>
+				<a href="consumer.html" class="preview-card">
+					<h3>Kuluttajat</h3>
+					<p>Uudet ja tarkistetut käytetyt laitteet yksityisasiakkaille. Pelikoneet, läppärit ja paljon muuta.</p>
+				</a>
+				<a href="softwaredevelopment.html" class="preview-card">
+					<h3>Ohjelmistokehitys</h3>
+					<p>REST API:t, web-sivut, tekoälypalvelut ja automaatio. Räätälöityjä ratkaisuja teidän tarpeisiinne.</p>
+				</a>
 			</div>
-		</div>  
+			<div class="preview-cta">
+				<p>Tarvitsetko apua IT-asioissa? <a href="contactus.html">Ota yhteyttä</a> – autamme mielellämme.</p>
+			</div>
+		</div>
+	</section>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
 </body>
 </html>

--- a/softwaredevelopment.html
+++ b/softwaredevelopment.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="REST API:t, integraatiot, web-sivut, tekoälypalvelut ja automaatio. Räätälöityä ohjelmistokehitystä yrityksille – NelePC, Tampere.">
+    <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
+	<title>NelePC – Ohjelmistokehitys</title>
+	<link rel="stylesheet" href="styles/softwaredevelopment.css">
+	<link rel="stylesheet" href="styles/footer.css">
+	<script src="helpers/common.js" defer></script>
+	<script src="helpers/staticPhotos.js" defer></script>
+</head>
+<body>
+	<header>
+        <img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
+        <button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
+        <nav>
+            <a href="index.html">Etusivu</a>
+            <a href="devices.html">Laitteet</a>
+            <a href="consumer.html">Kuluttajat</a>
+            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+            <a href="aboutus.html">Tietoa meistä</a>
+            <!-- <a href="blog.html">Blogi</a> -->
+			<a href="contactus.html">Ota yhteyttä</a>
+        </nav>
+    </header>
+
+	<div class="hero">
+		<div class="hero-text">
+			<h3>Ohjelmistokehitys</h3>
+			<p>Rakennamme räätälöityjä digitaalisia ratkaisuja – pienistä automaatiotyökaluista tekoälypohjaisiin palveluihin. Jokainen projekti suunnitellaan ja toteutetaan teidän tarpeidenne mukaisesti.</p>
+		</div>
+	</div>
+
+	<section class="services-section">
+		<div class="services-inner">
+
+			<h2 class="section-title">Mitä teemme</h2>
+
+			<div class="services-grid">
+
+				<div class="service-card">
+					<h4>REST API:t &amp; integraatiot</h4>
+					<p>Rakennamme selkeitä ja turvallisia REST API -rajapintoja järjestelmienne väliseen tiedonsiirtoon. Integroimme eri palveluja ja alustoja saumattomasti toisiinsa – olipa kyseessä toiminnanohjausjärjestelmä, verkkokauppa tai kolmannen osapuolen palvelu.</p>
+				</div>
+
+				<div class="service-card">
+					<h4>Paikalliset sovellukset</h4>
+					<p>Kehitämme pieniä, käytännöllisiä sovelluksia asiakkaan omille laitteille tai paikalliselle palvelimelle. Raportointityökalut, tiedostonhallintaratkaisut ja data-analytiikkasovellukset räätälöitynä teidän prosesseihanne.</p>
+				</div>
+
+				<div class="service-card">
+					<h4>Web-sivut</h4>
+					<p>Suunnittelemme ja toteutamme responsiiviset verkkosivut yrityksille, blogit sekä ajanvarausjärjestelmät. Sivustot ovat mobiiliystävällisiä, nopeita ja helppokäyttöisiä – kuten tämäkin sivu.</p>
+				</div>
+
+				<div class="service-card">
+					<h4>Tekoäly (AI) -palvelut</h4>
+					<p>Rakennamme mukautettuja tekoälyratkaisuja teidän liiketoimintaanne:</p>
+					<ul>
+						<li>Mukautetut RAG-putkilinjat ja tietämyskannat</li>
+						<li>Chatbotit verkkosivuille</li>
+						<li>Asiakkaan omaan aineistoon perustuva tietoassistentti</li>
+						<li>Ääniohjaussovellukset</li>
+						<li>Kuvantunnistusratkaisut</li>
+					</ul>
+				</div>
+
+				<div class="service-card">
+					<h4>Automaatio &amp; CI/CD</h4>
+					<p>Automatisoimme ohjelmistojen testauksen ja julkaisun CI/CD-putkilinjoilla. Muutokset kulkevat kehitysympäristöstä tuotantoon hallitusti, nopeasti ja luotettavasti ilman manuaalista työtä.</p>
+				</div>
+
+				<div class="service-card">
+					<h4>Infrastruktuuri koodina (IaC)</h4>
+					<p>Hallinnoimme pilvi-infrastruktuuria koodina Terraformin avulla. Muutokset ovat toistettavia, versionhallittuja ja dokumentoituja – ei enää käsin tehtyjä konfiguraatioita, joita kukaan ei muista.</p>
+				</div>
+
+			</div>
+
+			<div class="hosting-block">
+				<h3>Hosting</h3>
+				<p>Palvelut ja sovellukset isännöimme oletuksena <strong>Azuren pilvipalveluissa</strong> – skaalautuva, turvallinen ja helposti hallittava ympäristö. Jos teillä on jo oma hosting-ympäristö tai omat palvelimet, voimme käyttää myös niitä.</p>
+			</div>
+
+			<div class="pricing-block">
+				<h3>Hinnoittelu</h3>
+				<p>Jokainen projekti on yksilöllinen, joten hinnoittelu tehdään aina projektikohtaisesti teidän tarpeidenne ja laajuutenne mukaan. Kiinteää hinnastoa ei ole – sen sijaan tarjoamme avoimen keskustelun ja selkeän tarjouksen ennen työn aloittamista.</p>
+				<p><a href="contactus.html" class="cta-link">Ota yhteyttä ja suunnitellaan teille sopiva ratkaisu &rarr;</a></p>
+			</div>
+
+		</div>
+	</section>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+		</div>
+	</footer>
+</body>
+</html>

--- a/styles/aboutus.css
+++ b/styles/aboutus.css
@@ -82,7 +82,8 @@ nav a {
 }
 
 nav a:hover,
-nav a:focus {
+nav a:focus,
+nav a.active {
     background: #2d2d7b;
     color: #fff;
     text-decoration: none;

--- a/styles/consumer.css
+++ b/styles/consumer.css
@@ -81,7 +81,8 @@ nav a {
 }
 
 nav a:hover,
-nav a:focus {
+nav a:focus,
+nav a.active {
     background: #2d2d7b;
     color: #fff;
     text-decoration: none;

--- a/styles/contactus.css
+++ b/styles/contactus.css
@@ -65,7 +65,8 @@ nav a {
 }
 
 nav a:hover,
-nav a:focus {
+nav a:focus,
+nav a.active {
     background: #2d2d7b;
     color: #fff;
     text-decoration: none;

--- a/styles/devices.css
+++ b/styles/devices.css
@@ -3,7 +3,6 @@
 body {
     font-family: "League Spartan", sans-serif;
     margin: 0;
-    margin: 0;
     padding: 0;
     background-color: #1f1f52;
 }
@@ -82,7 +81,8 @@ nav a {
 }
 
 nav a:hover,
-nav a:focus {
+nav a:focus,
+nav a.active {
     background: #2d2d7b;
     color: #fff;
     text-decoration: none;
@@ -202,7 +202,7 @@ nav a:focus {
 .hero-text p {
     font-size: 0.9rem;
     max-width: 68ch;
-    line-height: 0.75;
+    line-height: 1.3;
     font-weight: 500;
 }
 

--- a/styles/footer.css
+++ b/styles/footer.css
@@ -1,0 +1,88 @@
+footer {
+    background-color: #13132e;
+    color: #c8c8ee;
+    font-family: "League Spartan", sans-serif;
+    padding: 2.5em 2em 0;
+}
+
+.footer-inner {
+    max-width: 960px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr;
+    gap: 2em;
+    padding-bottom: 2em;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.footer-logo {
+    width: 44px;
+    border-radius: 5%;
+    margin-bottom: 0.8em;
+    display: block;
+}
+
+.footer-col h4 {
+    color: #f1f1ff;
+    font-size: 0.9rem;
+    font-weight: 800;
+    margin: 0 0 0.8em 0;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.footer-col p,
+.footer-col a {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #a8a8cc;
+    text-decoration: none;
+    margin: 0 0 0.4em 0;
+    line-height: 1.4;
+    transition: color 0.15s;
+}
+
+.footer-col a:hover {
+    color: #ffffff;
+}
+
+.footer-company {
+    color: #d0d0ee !important;
+    font-weight: 700 !important;
+}
+
+.footer-bottom {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 1em 0 1.2em;
+    text-align: center;
+}
+
+.footer-bottom p {
+    font-size: 0.78rem;
+    color: #6868a0;
+    margin: 0;
+}
+
+@media (max-width: 700px) {
+    .footer-inner {
+        grid-template-columns: 1fr 1fr;
+        gap: 1.5em;
+    }
+    .footer-col:first-child {
+        grid-column: 1 / -1;
+    }
+}
+
+@media (max-width: 450px) {
+    footer {
+        padding: 2em 1.2em 0;
+    }
+    .footer-inner {
+        grid-template-columns: 1fr;
+    }
+    .footer-col:first-child {
+        grid-column: auto;
+    }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -81,7 +81,8 @@ nav a {
 }
 
 nav a:hover,
-nav a:focus {
+nav a:focus,
+nav a.active {
     background: #2d2d7b;
     color: #fff;
     text-decoration: none;
@@ -174,6 +175,79 @@ nav a:focus {
 }
 
 
+/* ── Service preview section (home page) ─────────── */
+.services-preview {
+    background-color: #1f1f52;
+    padding: 3em 1.5em 2em;
+}
+.services-preview-inner {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.services-preview h2 {
+    color: #f1f1ff;
+    font-size: 1.4rem;
+    font-weight: 800;
+    text-align: center;
+    margin: 0 0 1.5em 0;
+}
+.preview-cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.2em;
+    margin-bottom: 1.5em;
+}
+.preview-card {
+    display: block;
+    background-color: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 10px;
+    padding: 1.4em 1.6em;
+    text-decoration: none;
+    transition: background 0.2s, transform 0.15s;
+}
+.preview-card:hover,
+.preview-card:focus {
+    background-color: rgba(255,255,255,0.13);
+    transform: translateY(-3px);
+    outline: none;
+}
+.preview-card h3 {
+    margin: 0 0 0.5em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #ffffff;
+}
+.preview-card p {
+    margin: 0;
+    font-size: 0.87rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.preview-cta {
+    background-color: rgba(45,45,123,0.5);
+    border-radius: 10px;
+    padding: 1.4em 2em;
+    text-align: center;
+}
+.preview-cta p {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #d0d0f0;
+}
+.preview-cta a {
+    color: #ffffff;
+    font-weight: 700;
+    text-decoration: none;
+    border-bottom: 2px solid rgba(255,255,255,0.35);
+    transition: border-color 0.15s;
+}
+.preview-cta a:hover {
+    border-color: #ffffff;
+}
+
 @media (max-width: 700px) {
     header {
         flex-direction: row;
@@ -231,5 +305,11 @@ nav a:focus {
 
     .hero-text p {
         font-size: 1em;
+    }
+    .preview-cards {
+        grid-template-columns: 1fr;
+    }
+    .services-preview {
+        padding: 2em 1em 1.5em;
     }
 }

--- a/styles/softwaredevelopment.css
+++ b/styles/softwaredevelopment.css
@@ -1,0 +1,321 @@
+@import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@500;700&display=swap');
+
+body {
+    font-family: "League Spartan", sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #1f1f52;
+}
+
+/* ── Header & nav ─────────────────────────────────── */
+header {
+    background-color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0 2em;
+    height: 80px;
+    text-align: left;
+    position: relative;
+}
+.logo {
+    width: 50px;
+    border-radius: 5%;
+    margin: 0;
+    display: block;
+}
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 2em;
+    position: absolute;
+    right: 1em;
+    top: 1.5em;
+    cursor: pointer;
+    z-index: 10;
+}
+nav {
+    display: flex;
+    gap: 1em;
+    align-items: center;
+    margin: 0 auto;
+    justify-content: flex-end;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+    transition: none;
+}
+nav a {
+    color: #2d2d7b;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 1.1em;
+    padding: 0.3em 0.7em;
+    border-radius: 5px;
+    transition: background 0.2s, color 0.2s;
+    font-family: Arial, sans-serif;
+}
+nav a:hover,
+nav a:focus,
+nav a.active {
+    background: #2d2d7b;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* ── Hero banner ──────────────────────────────────── */
+.hero {
+    width: 100%;
+    max-width: 100vw;
+    height: 55vh;
+    min-height: 260px;
+    background-image: var(--bg-image);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.hero-text {
+    background-color: rgba(31, 31, 82, 0.65);
+    padding: 2em 2.5em;
+    border-radius: 10px;
+    max-width: 90%;
+    width: 640px;
+    color: white;
+    box-shadow: 0 0 14px rgba(0,0,0,0.35);
+    text-align: center;
+}
+.hero-text h3 {
+    margin: 0 0 0.5em 0;
+    font-size: 1.8rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.hero-text p {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #e8e8ff;
+}
+
+/* ── Services section ─────────────────────────────── */
+.services-section {
+    background-color: #1f1f52;
+    padding: 3em 1.5em 4em;
+}
+.services-inner {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.section-title {
+    color: #f1f1ff;
+    font-size: 1.5rem;
+    font-weight: 800;
+    margin: 0 0 1.5em 0;
+    text-align: center;
+    letter-spacing: 0.02em;
+}
+
+/* ── Service cards grid ───────────────────────────── */
+.services-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2em;
+    margin-bottom: 2.5em;
+}
+.service-card {
+    background-color: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 1.4em 1.6em;
+}
+.service-card h4 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #ffffff;
+}
+.service-card p {
+    margin: 0 0 0.4em 0;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.service-card ul {
+    margin: 0.4em 0 0 0;
+    padding-left: 1.2em;
+    color: #c8c8ee;
+}
+.service-card li {
+    font-size: 0.86rem;
+    font-weight: 500;
+    line-height: 1.5;
+    margin: 0.2em 0;
+}
+
+/* ── Hosting block ────────────────────────────────── */
+.hosting-block {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-left: 4px solid #4a4ab8;
+    border-radius: 0 10px 10px 0;
+    padding: 1.2em 1.6em;
+    margin-bottom: 1.8em;
+}
+.hosting-block h3 {
+    margin: 0 0 0.5em 0;
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.hosting-block p {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.hosting-block strong {
+    color: #ffffff;
+}
+
+/* ── Pricing block ────────────────────────────────── */
+.pricing-block {
+    background-color: rgba(45, 45, 123, 0.5);
+    border-radius: 10px;
+    padding: 1.6em 2em;
+    text-align: center;
+}
+.pricing-block h3 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.pricing-block p {
+    margin: 0 0 0.8em 0;
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.5;
+    color: #d0d0f0;
+    max-width: 60ch;
+    margin-left: auto;
+    margin-right: auto;
+}
+.cta-link {
+    display: inline-block;
+    background-color: #2d2d7b;
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 0.95rem;
+    padding: 0.75em 1.6em;
+    border-radius: 7px;
+    transition: background 0.2s, transform 0.15s;
+    margin-top: 0.4em;
+}
+.cta-link:hover,
+.cta-link:focus {
+    background-color: #3d3da0;
+    transform: translateY(-2px);
+    outline: none;
+}
+
+/* ── Mobile ≤ 700px ──────────────────────────────── */
+@media (max-width: 700px) {
+    header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        height: 80px;
+        padding: 0 1em;
+        position: relative;
+    }
+    .logo {
+        margin: 0;
+    }
+    .menu-toggle {
+        display: block;
+        position: static;
+        margin-left: auto;
+        z-index: 30;
+    }
+    nav {
+        flex-direction: column;
+        background: #fff;
+        position: absolute;
+        top: 80px;
+        left: 10%;
+        width: 80%;
+        box-shadow: 0 2px 10px rgba(16, 15, 15, 0.1);
+        border-radius: 0 0 10px 10px;
+        transform: translateY(-30px);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.3s cubic-bezier(.4,2,.6,1), opacity 0.3s;
+        z-index: 20;
+        margin: 0;
+        display: flex;
+        visibility: hidden;
+    }
+    nav.open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+        visibility: visible;
+    }
+    .hero {
+        height: 45vh;
+        min-height: 220px;
+    }
+    .hero-text {
+        width: 88%;
+        padding: 1.2em 1.4em;
+    }
+    .hero-text h3 {
+        font-size: 1.4rem;
+    }
+    .hero-text p {
+        font-size: 0.9rem;
+    }
+    .services-grid {
+        grid-template-columns: 1fr;
+    }
+    .services-section {
+        padding: 2em 1em 3em;
+    }
+    .pricing-block {
+        padding: 1.4em 1.2em;
+    }
+}
+
+/* ── Mobile ≤ 450px ──────────────────────────────── */
+@media (max-width: 450px) {
+    .hero {
+        height: auto;
+        min-height: 200px;
+        padding: 2em 0;
+    }
+    .hero-text {
+        width: 92%;
+        padding: 1em;
+    }
+    .hero-text h3 {
+        font-size: 1.2rem;
+    }
+    .hero-text p {
+        font-size: 0.85rem;
+    }
+    .service-card {
+        padding: 1em 1.1em;
+    }
+    .hosting-block,
+    .pricing-block {
+        padding: 1em;
+    }
+}


### PR DESCRIPTION
## Summary

- **New page** – `softwaredevelopment.html` with service cards (REST APIs, integrations, local apps, web sites, AI/RAG/chatbots/voice/image detection, CI/CD, IaC/Terraform), hosting info (Azure default, own hosting supported) and a pricing + contact CTA section
- **Shared footer** – added to all 6 pages: logo, phone, email, service links, company links, copyright
- **Home page service cards** – three clickable preview cards (Laitteet, Kuluttajat, Ohjelmistokehitys) below the hero with a CTA strip
- **Active nav highlight** – `common.js` auto-detects current page and sets `.active` class; all CSS files updated with `nav a.active` style
- **SEO & accessibility** – `lang="fi"`, unique `<title>` and `<meta name="description">` on all 6 pages
- **Bug fixes** – `devices.css`: removed duplicate `margin: 0`, fixed `line-height: 0.75` → `1.3`

## Test plan

- [ ] Open each page and verify the correct nav link is highlighted
- [ ] Check footer appears on all pages with working phone/email links
- [ ] Verify home page service cards link to the correct pages
- [ ] Open `softwaredevelopment.html` and confirm all service cards and pricing block render correctly
- [ ] Resize to mobile (≤700px) – hamburger menu works, footer stacks, service cards go single-column
- [ ] Check page titles in browser tab on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)