### PR TITLE
Add privacy page and card layouts for Laitteet and Kuluttajat

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="NelePC on tamperelainen kahden veljeksen IT-yritys. Palvelemme yrityksiä ja yksityisasiakkaita laitehankinnoissa, ohjelmistokehityksessä ja IT-tuessa koko Pirkanmaalla.">
-    <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
+	<link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
 	<title>NelePC – Tietoa meistä</title>
 	<link rel="stylesheet" href="styles/aboutus.css">
 	<link rel="stylesheet" href="styles/footer.css">
@@ -13,31 +13,73 @@
 </head>
 <body>
 	<header>
-        <img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
-        <button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
-        <nav>
-            <a href="index.html">Etusivu</a>
-            <a href="devices.html">Laitteet</a>
-            <a href="consumer.html">Kuluttajat</a>
-            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
-            <a href="aboutus.html">Tietoa meistä</a>
-            <!-- <a href="blog.html">Blogi</a> -->
+		<img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
+		<button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
+		<nav>
+			<a href="index.html">Etusivu</a>
+			<a href="devices.html">Laitteet</a>
+			<a href="consumer.html">Kuluttajat</a>
+			<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			<a href="aboutus.html">Tietoa meistä</a>
+			<!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
-        </nav>
-    </header>
+		</nav>
+	</header>
+
 	<div class="hero">
-			<div class="hero-text">
-				<h3>NelePC - Pirkanmaan paras IT-kaveri</h3>
-				<p>Olemme on tamperelainen kahden veljeksen perustama IT-yritys, joka tarjoaa selkeitä ja luotettavia ratkaisuja yritysten ja kuluttajien arjen laitetarpeisiin. Autamme asiakkaitamme löytämään juuri heidän tarpeisiinsa sopivat laitteet, aina kilpailukykyiseen hintaan ja käyttövalmiina.</p>
-				<p>Toimimme joustavasti koko Pirkanmaan alueella ja autamme asiakkaitamme laitehankinnoista käyttöönottoon, tietoturvasta ylläpitoon. Meille jokainen asiakas on tärkeä ja siksi palvelemme ripeästi, rehellisesti ja asiakkaan tarpeet edellä.</p><br>
-				<h4>Yhteystiedot:</h4>
-				<p>N-ele Oy (3150563-4)</p>
-				<p>044 3600 809</p>
-				<p>info@nelepc.com</p>
-				<p>www.nelepc.com</p><br>
-				<p>Voit ottaa meihin yhteyttä puhelimitse, sähköpostilla tai yhteydenottolomakkeella. Autamme mielellämme!</p>
-			</div>
+		<div class="hero-text">
+			<h3>Pirkanmaan paras IT-kaveri</h3>
+			<p>Tamperelainen kahden veljeksen IT-yritys – selkeitä ja luotettavia ratkaisuja yritysten ja kuluttajien arjen tarpeisiin.</p>
 		</div>
+	</div>
+
+	<section class="content-section">
+		<div class="content-inner">
+
+			<div class="cards-grid">
+				<div class="card">
+					<h4>Keitä olemme</h4>
+					<p>Olemme tamperelainen kahden veljeksen perustama IT-yritys. Autamme asiakkaitamme löytämään juuri heidän tarpeisiinsa sopivat laitteet ja ratkaisut – aina kilpailukykyiseen hintaan ja käyttövalmiina.</p>
+				</div>
+				<div class="card">
+					<h4>Palvelualue</h4>
+					<p>Toimimme joustavasti koko <strong>Pirkanmaan alueella</strong>. Laitehankinnoista käyttöönottoon, tietoturvasta ylläpitoon ja ohjelmistokehityksestä pilvipalveluihin.</p>
+				</div>
+				<div class="card">
+					<h4>Tapamme toimia</h4>
+					<p>Meille jokainen asiakas on tärkeä. Palvelemme ripeästi, rehellisesti ja asiakkaan tarpeet edellä – ilman turhaa teknistä jargonia.</p>
+				</div>
+				<div class="card">
+					<h4>Mitä teemme</h4>
+					<p>Laitehankinnat yrityksille ja kuluttajille, ohjelmistokehitys, web-sivut, tekoälypalvelut sekä infrastruktuuri ja automaatio Azuressa.</p>
+				</div>
+			</div>
+
+			<div class="contact-info-block">
+				<h3>Yhteystiedot</h3>
+				<div class="contact-grid">
+					<div class="contact-item">
+						<span class="contact-label">Yritys</span>
+						<span>N-ele Oy (3150563-4)</span>
+					</div>
+					<div class="contact-item">
+						<span class="contact-label">Puhelin</span>
+						<a href="tel:0443600809">044 3600 809</a>
+					</div>
+					<div class="contact-item">
+						<span class="contact-label">Sähköposti</span>
+						<a href="mailto:info@n-ele.com">info@n-ele.com</a>
+					</div>
+					<div class="contact-item">
+						<span class="contact-label">Verkkosivu</span>
+						<a href="https://www.nelepc.com">www.nelepc.com</a>
+					</div>
+				</div>
+				<p class="contact-note">Voit ottaa meihin yhteyttä puhelimitse, sähköpostilla tai <a href="contactus.html">yhteydenottolomakkeella</a>. Autamme mielellämme!</p>
+			</div>
+
+		</div>
+	</section>
 
 	<footer>
 		<div class="footer-inner">
@@ -45,7 +87,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/aboutus.html
+++ b/aboutus.html
@@ -60,7 +60,7 @@
 			</div>
 		</div>
 		<div class="footer-bottom">
-			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään &nbsp;·&nbsp; <a href="privacy.html">Tietosuojaseloste</a></p>
 		</div>
 	</footer>
 </body>

--- a/consumer.html
+++ b/consumer.html
@@ -77,7 +77,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/consumer.html
+++ b/consumer.html
@@ -4,72 +4,72 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Käyttövalmiit tietokoneet, oheislaitteet ja tarkistetut käytetyt laitteet kuluttajille. Pelikoneet, kannettavat ja paljon muuta – NelePC, Tampere.">
-    <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
+	<link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
 	<title>NelePC – Kuluttajat</title>
 	<link rel="stylesheet" href="styles/consumer.css">
 	<link rel="stylesheet" href="styles/footer.css">
-	<style>
-		.contact-link {
-			color: inherit;
-			text-decoration: none;
-			display: inline-block;
-			position: relative;
-			transition: color 160ms ease, transform 120ms ease;
-		}
-		.contact-link::after {
-			content: "";
-			display: block;
-			height: 2px;
-			background: rgba(255,255,255,0.85);
-			position: absolute;
-			left: 0;
-			right: 0;
-			bottom: -3px;
-			transform-origin: left center;
-			transform: scaleX(0);
-			transition: transform 200ms cubic-bezier(.2,.8,.2,1);
-		}
-		.contact-link:hover,
-		.contact-link:focus {
-			color: #aaaaa9;
-			outline: none;
-			transform: translateY(-2px);
-		}
-		.contact-link:hover::after,
-		.contact-link:focus::after {
-			transform: scaleX(1);
-		}
-		.contact-link:focus-visible {
-			box-shadow: 0 0 0 3px rgba(255,210,77,0.12);
-		}
-	</style>
 	<script src="helpers/common.js" defer></script>
 	<script src="helpers/staticPhotos.js" defer></script>
 </head>
 <body>
 	<header>
-        <img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
-        <button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
-        <nav>
-            <a href="index.html">Etusivu</a>
-            <a href="devices.html">Laitteet</a>
-            <a href="consumer.html">Kuluttajat</a>
-            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
-            <a href="aboutus.html">Tietoa meistä</a>
-            <!-- <a href="blog.html">Blogi</a> -->
+		<img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
+		<button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
+		<nav>
+			<a href="index.html">Etusivu</a>
+			<a href="devices.html">Laitteet</a>
+			<a href="consumer.html">Kuluttajat</a>
+			<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			<a href="aboutus.html">Tietoa meistä</a>
+			<!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
-        </nav>
-    </header>
-		<div class="hero">
-			<div class="hero-text">
-					<h3>Käyttövalmiit tietokoneet helposti ja vaivattomasti</h3>
-					<p>Tarjoamme laadukkaita tietokoneita ja oheislaitteita myös kuluttajille. Olitpa pelaaja, opiskelija tai kotikäyttäjä, saat meiltä juuri sinulle sopivan laitteen käyttövalmiina ja ilman turhaa säätöä.</p>
-					<p>Uudet tietokoneet toimitetaan tilauksesta, esiasennettuina ja heti käyttövalmiina. Valittavana on tehokkaita pelitietokoneita toiveidesi mukaan sekä laitteita peruskäyttöön ja kannettavia arkeen, opiskeluun tai etätyöhön.</p>
-					<p>Tarjoamme myös oheislaitteita kuten näyttöjä, näppäimistöjä, hiiriä ja kuulokkeita.</p>
-					<p>Tarkistetut ja toimintavarmat käytetyt laitteet fiksuun hintaan. Käytetty tietokone, kannettava tai oheislaite on edullinen ja vastuullinen valinta, joka sopii monenlaisiin tarpeisiin.</p>
-					<h4><a href="contactus.html" class="contact-link">Ota yhteyttä</a> niin autamme löytämään sinulle sopivan laitteen.</h4>
-			</div>
+		</nav>
+	</header>
+
+	<div class="hero">
+		<div class="hero-text">
+			<h3>Kuluttajille</h3>
+			<p>Käyttövalmiit tietokoneet helposti ja vaivattomasti – olitpa pelaaja, opiskelija tai kotikäyttäjä. Saat meiltä juuri sinulle sopivan laitteen ilman turhaa säätöä.</p>
 		</div>
+	</div>
+
+	<section class="content-section">
+		<div class="content-inner">
+
+			<h2 class="section-title">Mitä tarjoamme</h2>
+
+			<div class="cards-grid">
+				<div class="card">
+					<h4>Pelikoneet</h4>
+					<p>Tehokkaat pelitietokoneet toiveidesi mukaan rakennettuna. Toimitetaan esiasennettuina ja heti pelivalmiina – ei tarvitse itse säätää.</p>
+				</div>
+				<div class="card">
+					<h4>Peruskäyttö &amp; etätyö</h4>
+					<p>Luotettavat pöytäkoneet ja kannettavat arkikäyttöön, opiskeluun ja etätöihin. Selkeä ja toimiva paketti ilman ylimääräistä.</p>
+				</div>
+				<div class="card">
+					<h4>Käytetyt laitteet</h4>
+					<p>Tarkistetut ja toimintavarmat käytetyt tietokoneet, kannettavat ja oheislaitteet fiksuun hintaan. Edullinen ja vastuullinen valinta.</p>
+				</div>
+				<div class="card">
+					<h4>Oheislaitteet</h4>
+					<p>Näytöt, näppäimistöt, hiiret, kuulokkeet ja muut oheislaitteet. Sopivat niin pelaamisen kuin toimistotyön tarpeisiin.</p>
+				</div>
+			</div>
+
+			<div class="info-block">
+				<h3>Käyttövalmis heti paketista</h3>
+				<p>Kaikki uudet laitteet toimitetaan <strong>esiasennettuina ja käyttövalmiina</strong>. Tarvittavat ohjelmistot ja asetukset hoidetaan valmiiksi – sinun tarvitsee vain käynnistää laite ja aloittaa käyttö.</p>
+			</div>
+
+			<div class="cta-block">
+				<h3>Löydetään sinulle sopiva laite</h3>
+				<p>Kerro tarpeistasi niin autamme valitsemaan juuri sinulle sopivan laitteen oikeaan hintaan.</p>
+				<a href="contactus.html" class="cta-link">Ota yhteyttä &rarr;</a>
+			</div>
+
+		</div>
+	</section>
 
 	<footer>
 		<div class="footer-inner">

--- a/contactus.html
+++ b/contactus.html
@@ -74,7 +74,7 @@
 			</div>
 		</div>
 		<div class="footer-bottom">
-			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään &nbsp;·&nbsp; <a href="privacy.html">Tietosuojaseloste</a></p>
 		</div>
 	</footer>
 

--- a/contactus.html
+++ b/contactus.html
@@ -59,7 +59,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>
@@ -109,7 +109,7 @@
 					form.reset();
 				} else {
 					result.classList.add('form-result--error');
-					result.textContent = 'Jokin meni pieleen. Yritä uudelleen tai ota yhteyttä sähköpostilla: info@nelepc.com';
+					result.textContent = 'Jokin meni pieleen. Yritä uudelleen tai ota yhteyttä sähköpostilla: info@n-ele.com';
 				}
 			} catch (error) {
 				result.classList.add('form-result--error');

--- a/devices.html
+++ b/devices.html
@@ -4,81 +4,85 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Laadukkaat yritystietokoneet, kannettavat, puhelimet ja AV-laitteet kilpailukykyiseen hintaan. Toimitus ja käyttöönotto avaimet käteen – NelePC, Tampere.">
-    <link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
+	<link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
 	<title>NelePC – Laitteet</title>
 	<link rel="stylesheet" href="styles/devices.css">
 	<link rel="stylesheet" href="styles/footer.css">
-	<style>
-		.contact-link {
-			color: inherit;
-			text-decoration: none;
-			display: inline-block;
-			position: relative;
-			transition: color 160ms ease, transform 120ms ease;
-		}
-		.contact-link::after {
-			content: "";
-			display: block;
-			height: 2px;
-			background: rgba(255,255,255,0.85);
-			position: absolute;
-			left: 0;
-			right: 0;
-			bottom: -3px;
-			transform-origin: left center;
-			transform: scaleX(0);
-			transition: transform 200ms cubic-bezier(.2,.8,.2,1);
-		}
-		.contact-link:hover,
-		.contact-link:focus {
-			color: #aaaaa9;
-			outline: none;
-			transform: translateY(-2px);
-		}
-		.contact-link:hover::after,
-		.contact-link:focus::after {
-			transform: scaleX(1);
-		}
-		.contact-link:focus-visible {
-			box-shadow: 0 0 0 3px rgba(255,210,77,0.12);
-		}
-	</style>
 	<script src="helpers/common.js" defer></script>
 	<script src="helpers/staticPhotos.js" defer></script>
 </head>
 <body>
 	<header>
-        <img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
-        <button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
-        <nav>
-            <a href="index.html">Etusivu</a>
-            <a href="devices.html">Laitteet</a>
-            <a href="consumer.html">Kuluttajat</a>
-            <a href="softwaredevelopment.html">Ohjelmistokehitys</a>
-            <a href="aboutus.html">Tietoa meistä</a>
-            <!-- <a href="blog.html">Blogi</a> -->
+		<img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
+		<button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
+		<nav>
+			<a href="index.html">Etusivu</a>
+			<a href="devices.html">Laitteet</a>
+			<a href="consumer.html">Kuluttajat</a>
+			<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			<a href="aboutus.html">Tietoa meistä</a>
+			<!-- <a href="blog.html">Blogi</a> -->
 			<a href="contactus.html">Ota yhteyttä</a>
-        </nav>
-    </header>
-		<div class="hero">
-			<div class="hero-text">
-				<h3>Tarjoamme laitteet koko organisaatiollenne, alkaen hankinnasta aina turvalliseen kierrätykseen asti.</h3>
-				<h4>Edustamme tunnettuja valmistajia kuten Dell, HP, Lenovo ja Apple. Laitteet toimitetaan aina hyvällä saatavuudella ja kilpailukykyiseen hintaan, teidän tarpeidenne mukaisesti.</h4>
-				<h4>Valikoimastamme löydät</h4>
+		</nav>
+	</header>
 
-				<p>Pöytäkoneet ja tehotyöasemat.</p>
-				<p>Kannettavat, puhelimet ja tabletit.</p>
-				<p>AV-laitteet ja neuvotteluratkaisut.</p>
-				<p>Oheislaitteet (näytöt, näppäimistöt, hiiret, kuulokkeet jne.).</p>
-				<p>Kamera- ja kulunvalvonta.</p>
-				<p>Digitaaliset mainos- ja infonäytöt.</p><br>
-
-
-				<h4>Hoidamme koko käyttöönoton puolestasi alusta loppuun. Autamme valitsemaan juuri teidän yrityksellenne sopivat laitteet, esiasennamme tarvittavat ohjelmistot ja asetukset, ja toimitamme laitteet käyttövalmiina suoraan paikan päälle. Tarvittaessa viimeistelemme asennuksen asiakkaan tiloissa, jotta kaikki toimii heti ilman ylimääräistä vaivaa. Käyttöönotto on nopeaa, sujuvaa ja täysin teidän tarpeisiinne räätälöityä.</h4>
-				<h4>Tarjoamme joustavat hankintatavat, jotka mukautuvat yrityksesi tilanteeseen. Laitteet voidaan hankkia ostolaskulla, leasing-sopimuksella tai rahoituksen kautta, juuri teille sopivalla tavalla. Tarjoamme aina selkeän kokonaisuuden, joka on teille järkevä, käytännöllinen ja aidosti toimiva ratkaisu.</h4>
-				<h4><a href="contactus.html" class="contact-link">Ota yhteyttä</a> niin hoidetaan yhdessä kaikki yrityksesi IT-laitteet kerrasta kuntoon.</h4>
-			</div>
+	<div class="hero">
+		<div class="hero-text">
+			<h3>Laitteet yrityksille</h3>
+			<p>Tarjoamme laitteet koko organisaatiollenne – hankinnasta käyttöönottoon ja turvalliseen kierrätykseen asti. Edustamme tunnettuja valmistajia kuten Dell, HP, Lenovo ja Apple.</p>
 		</div>
+	</div>
+
+	<section class="content-section">
+		<div class="content-inner">
+
+			<h2 class="section-title">Valikoimastamme löydät</h2>
+
+			<div class="cards-grid">
+				<div class="card">
+					<h4>Pöytäkoneet &amp; tehotyöasemat</h4>
+					<p>Tehokkaat työpöytäkoneet ja workstationit vaativaan yritystoimintaan. Konfiguroitavissa teidän tarpeidenne mukaan.</p>
+				</div>
+				<div class="card">
+					<h4>Kannettavat, puhelimet &amp; tabletit</h4>
+					<p>Mobiilityövälineet etätyöhön, toimistokäyttöön ja liikkuvaan työhön – kaikki tunnettuilta valmistajilta.</p>
+				</div>
+				<div class="card">
+					<h4>AV-laitteet &amp; neuvotteluratkaisut</h4>
+					<p>Näytöt, projektorit, web-kamerat ja täydelliset neuvotteluhuoneratkaisut etä- ja hybridipalavereihin.</p>
+				</div>
+				<div class="card">
+					<h4>Oheislaitteet</h4>
+					<p>Näytöt, näppäimistöt, hiiret, kuulokkeet, telakat ja muut oheislaitteet koko henkilöstölle.</p>
+				</div>
+				<div class="card">
+					<h4>Kamera- &amp; kulunvalvonta</h4>
+					<p>Yritysturvallisuuden ratkaisut: valvontakamerat, kulunvalvontajärjestelmät ja niihin liittyvä laitteisto.</p>
+				</div>
+				<div class="card">
+					<h4>Digitaaliset näytöt</h4>
+					<p>Mainos- ja infonäyttöratkaisut toimistoihin, myymälöihin ja julkisiin tiloihin. Asennus ja käyttöönotto mukaan lukien.</p>
+				</div>
+			</div>
+
+			<div class="info-block">
+				<h3>Käyttöönotto avaimet käteen</h3>
+				<p>Hoidamme koko käyttöönoton puolestasi. Autamme valitsemaan sopivat laitteet, esiasennamme tarvittavat ohjelmistot ja asetukset, ja toimitamme laitteet käyttövalmiina suoraan paikan päälle. Tarvittaessa viimeistelemme asennuksen asiakkaan tiloissa – ilman ylimääräistä vaivaa.</p>
+			</div>
+
+			<div class="info-block">
+				<h3>Joustavat hankintavaihtoehdot</h3>
+				<p>Laitteet voidaan hankkia <strong>ostolaskulla</strong>, <strong>leasing-sopimuksella</strong> tai <strong>rahoituksen kautta</strong> – juuri teille sopivalla tavalla. Tarjoamme aina selkeän kokonaisuuden, joka on käytännöllinen ja aidosti toimiva ratkaisu.</p>
+			</div>
+
+			<div class="cta-block">
+				<h3>Hoidetaan yhdessä</h3>
+				<p>Ota yhteyttä niin kartoitetaan yrityksesi tarpeet ja hoidetaan kaikki IT-laitteet kerrasta kuntoon.</p>
+				<a href="contactus.html" class="cta-link">Ota yhteyttä &rarr;</a>
+			</div>
+
+		</div>
+	</section>
 
 	<footer>
 		<div class="footer-inner">

--- a/devices.html
+++ b/devices.html
@@ -90,7 +90,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 			</div>
 		</div>
 		<div class="footer-bottom">
-			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään &nbsp;·&nbsp; <a href="privacy.html">Tietosuojaseloste</a></p>
 		</div>
 	</footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/privacy.html
+++ b/privacy.html
@@ -35,10 +35,10 @@
 			<p>N-ele Oy (Y-tunnus: 3150563-4)<br>
 			Tampere, Suomi<br>
 			Puhelin: <a href="tel:0443600809">044 3600 809</a><br>
-			Sähköposti: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			Sähköposti: <a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 
 			<h2>2. Yhteyshenkilö tietosuoja-asioissa</h2>
-			<p>Tietosuojaan liittyvissä kysymyksissä voit ottaa yhteyttä sähköpostitse: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			<p>Tietosuojaan liittyvissä kysymyksissä voit ottaa yhteyttä sähköpostitse: <a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 
 			<h2>3. Henkilötietojen käsittelyn tarkoitus</h2>
 			<p>Käsittelemme henkilötietoja ainoastaan yhteydenottopyyntöjen vastaanottamiseen ja käsittelemiseen. Tietoja ei käytetä markkinointiin ilman erillistä suostumusta eikä luovuteta kolmansille osapuolille myynti- tai markkinointitarkoituksiin.</p>
@@ -78,7 +78,7 @@
 				<li><strong>Oikeus vastustaa käsittelyä</strong> – voit vastustaa henkilötietojesi käsittelyä</li>
 				<li><strong>Oikeus tehdä valitus</strong> – voit tehdä valituksen tietosuojaviranomaiselle (tietosuoja.fi)</li>
 			</ul>
-			<p>Oikeuksien käyttämiseksi ota yhteyttä: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			<p>Oikeuksien käyttämiseksi ota yhteyttä: <a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 
 			<h2>11. Muutokset tietosuojaselosteeseen</h2>
 			<p>Pidätämme oikeuden päivittää tätä tietosuojaselostetta. Merkittävistä muutoksista ilmoitetaan verkkosivuston kautta. Suosittelemme tarkistamaan selosteen säännöllisesti.</p>
@@ -92,7 +92,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="NelePC – N-ele Oy:n tietosuojaseloste. Tietoa henkilötietojen käsittelystä ja rekisteröidyn oikeuksista.">
+	<link rel="icon" type="image/png" href="/assets/LOGO_N-ele-b_w.png">
+	<title>NelePC – Tietosuojaseloste</title>
+	<link rel="stylesheet" href="styles/privacy.css">
+	<link rel="stylesheet" href="styles/footer.css">
+	<script src="helpers/common.js" defer></script>
+</head>
+<body>
+	<header>
+		<img src="assets/LOGO_N-ele-transparent.png" class="logo" alt="main Logo">
+		<button class="menu-toggle" aria-label="Avaa valikko">&#9776;</button>
+		<nav>
+			<a href="index.html">Etusivu</a>
+			<a href="devices.html">Laitteet</a>
+			<a href="consumer.html">Kuluttajat</a>
+			<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			<a href="aboutus.html">Tietoa meistä</a>
+			<!-- <a href="blog.html">Blogi</a> -->
+			<a href="contactus.html">Ota yhteyttä</a>
+		</nav>
+	</header>
+
+	<section class="privacy-section">
+		<div class="privacy-inner">
+
+			<h1>Tietosuojaseloste</h1>
+			<p class="updated">Päivitetty: toukokuu 2025</p>
+
+			<h2>1. Rekisterinpitäjä</h2>
+			<p>N-ele Oy (Y-tunnus: 3150563-4)<br>
+			Tampere, Suomi<br>
+			Puhelin: <a href="tel:0443600809">044 3600 809</a><br>
+			Sähköposti: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+
+			<h2>2. Yhteyshenkilö tietosuoja-asioissa</h2>
+			<p>Tietosuojaan liittyvissä kysymyksissä voit ottaa yhteyttä sähköpostitse: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+
+			<h2>3. Henkilötietojen käsittelyn tarkoitus</h2>
+			<p>Käsittelemme henkilötietoja ainoastaan yhteydenottopyyntöjen vastaanottamiseen ja käsittelemiseen. Tietoja ei käytetä markkinointiin ilman erillistä suostumusta eikä luovuteta kolmansille osapuolille myynti- tai markkinointitarkoituksiin.</p>
+
+			<h2>4. Käsiteltävät henkilötiedot</h2>
+			<p>Yhteydenottolomakkeen kautta keräämme seuraavat tiedot:</p>
+			<ul>
+				<li>Nimi</li>
+				<li>Sähköpostiosoite</li>
+				<li>Puhelinnumero (vapaaehtoinen)</li>
+				<li>Vapaamuotoinen viesti</li>
+			</ul>
+
+			<h2>5. Käsittelyn oikeusperuste</h2>
+			<p>Henkilötietojen käsittely perustuu rekisteröidyn suostumukseen (GDPR artikla 6(1)(a)) sekä rekisterinpitäjän oikeutettuun etuun vastata asiakkaiden yhteydenottoihin (GDPR artikla 6(1)(f)).</p>
+
+			<h2>6. Tietojen säilytysaika</h2>
+			<p>Säilytämme yhteydenottotiedot niin kauan kuin ne ovat tarpeellisia yhteydenoton käsittelemiseksi ja mahdollisen asiakassuhteen hoitamiseksi, kuitenkin enintään 24 kuukautta yhteydenotosta.</p>
+
+			<h2>7. Tietojen luovutus ja kolmannet osapuolet</h2>
+			<p>Yhteydenottolomakkeen tiedot välitetään sähköpostiimme <strong>Web3Forms</strong>-palvelun kautta (web3forms.com). Web3Forms toimii tietojenkäsittelijänä eikä käytä tietojasi omiin tarkoituksiinsa. Palvelun tietosuojaseloste on saatavilla osoitteessa <strong>web3forms.com/privacy</strong>.</p>
+			<p>Emme luovuta henkilötietoja muille kolmansille osapuolille ilman rekisteröidyn suostumusta, ellei laki sitä velvoita.</p>
+
+			<h2>8. Tietojen siirto EU:n ulkopuolelle</h2>
+			<p>Web3Forms-palvelu saattaa käsitellä tietoja EU:n ulkopuolella. Palvelu noudattaa GDPR:n vaatimuksia tiedonsiirtojen osalta.</p>
+
+			<h2>9. Evästeet</h2>
+			<p>Tämä verkkosivusto ei käytä seuranta- tai analytiikkaevästeitä. Sivusto ei kerää tietoja selailukäyttäytymisestäsi eikä käytä kolmannen osapuolen mainontapalveluita.</p>
+
+			<h2>10. Rekisteröidyn oikeudet</h2>
+			<p>Sinulla on GDPR:n nojalla seuraavat oikeudet:</p>
+			<ul>
+				<li><strong>Oikeus saada pääsy tietoihin</strong> – voit pyytää kopiota sinusta tallennetuista tiedoista</li>
+				<li><strong>Oikeus tietojen oikaisemiseen</strong> – voit pyytää virheellisten tietojen korjaamista</li>
+				<li><strong>Oikeus tietojen poistamiseen</strong> – voit pyytää tietojesi poistamista</li>
+				<li><strong>Oikeus käsittelyn rajoittamiseen</strong> – voit pyytää tietojesi käsittelyn rajoittamista</li>
+				<li><strong>Oikeus vastustaa käsittelyä</strong> – voit vastustaa henkilötietojesi käsittelyä</li>
+				<li><strong>Oikeus tehdä valitus</strong> – voit tehdä valituksen tietosuojaviranomaiselle (tietosuoja.fi)</li>
+			</ul>
+			<p>Oikeuksien käyttämiseksi ota yhteyttä: <a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+
+			<h2>11. Muutokset tietosuojaselosteeseen</h2>
+			<p>Pidätämme oikeuden päivittää tätä tietosuojaselostetta. Merkittävistä muutoksista ilmoitetaan verkkosivuston kautta. Suosittelemme tarkistamaan selosteen säännöllisesti.</p>
+
+		</div>
+	</section>
+
+	<footer>
+		<div class="footer-inner">
+			<div class="footer-col">
+				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
+				<p class="footer-company">N-ele Oy (3150563-4)</p>
+				<p><a href="tel:0443600809">044 3600 809</a></p>
+				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+			</div>
+			<div class="footer-col">
+				<h4>Palvelut</h4>
+				<a href="devices.html">Laitteet</a>
+				<a href="consumer.html">Kuluttajat</a>
+				<a href="softwaredevelopment.html">Ohjelmistokehitys</a>
+			</div>
+			<div class="footer-col">
+				<h4>Yritys</h4>
+				<a href="aboutus.html">Tietoa meistä</a>
+				<a href="contactus.html">Ota yhteyttä</a>
+			</div>
+		</div>
+		<div class="footer-bottom">
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään &nbsp;·&nbsp; <a href="privacy.html">Tietosuojaseloste</a></p>
+		</div>
+	</footer>
+</body>
+</html>

--- a/softwaredevelopment.html
+++ b/softwaredevelopment.html
@@ -99,7 +99,7 @@
 				<img src="assets/LOGO_N-ele-transparent.png" alt="NelePC" class="footer-logo">
 				<p class="footer-company">N-ele Oy (3150563-4)</p>
 				<p><a href="tel:0443600809">044 3600 809</a></p>
-				<p><a href="mailto:info@nelepc.com">info@nelepc.com</a></p>
+				<p><a href="mailto:info@n-ele.com">info@n-ele.com</a></p>
 			</div>
 			<div class="footer-col">
 				<h4>Palvelut</h4>

--- a/softwaredevelopment.html
+++ b/softwaredevelopment.html
@@ -114,7 +114,7 @@
 			</div>
 		</div>
 		<div class="footer-bottom">
-			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään</p>
+			<p>© 2025 N-ele Oy – Kaikki oikeudet pidätetään &nbsp;·&nbsp; <a href="privacy.html">Tietosuojaseloste</a></p>
 		</div>
 	</footer>
 </body>

--- a/styles/aboutus.css
+++ b/styles/aboutus.css
@@ -1,6 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@500;700&display=swap');
 
-
 body {
     font-family: "League Spartan", sans-serif;
     margin: 0;
@@ -17,36 +16,12 @@ header {
     text-align: left;
     position: relative;
 }
-main {
-    max-width: 800px;
-    margin: 2em auto;
-    padding: 1em;
-    background-color: #67649662;
-    border-radius: 5px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-.post {
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-    color: #ffffff;
-}
-.post:last-child {
-    border-bottom: none;
-}
-.date {
-    color: #ffffff;
-    font-size: 0.9em;
-    margin-top: -0.5em;
-    margin-bottom: 1em;
-}
 .logo {
     width: 50px;
     border-radius: 5%;
     margin: 0;
     display: block;
 }
-
 .menu-toggle {
     display: none;
     background: none;
@@ -69,7 +44,6 @@ nav {
     transform: none;
     transition: none;
 }
-
 nav a {
     color: #2d2d7b;
     text-decoration: none;
@@ -78,9 +52,8 @@ nav a {
     padding: 0.3em 0.7em;
     border-radius: 5px;
     transition: background 0.2s, color 0.2s;
-    font-family: Arial, sans-serif; 
+    font-family: Arial, sans-serif;
 }
-
 nav a:hover,
 nav a:focus,
 nav a.active {
@@ -89,146 +62,147 @@ nav a.active {
     text-decoration: none;
 }
 
-.contact-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    margin-top: 1em;
-}
-
-.contact-form label {
-    color: #ffffff;
-    font-weight: bold;
-    margin-bottom: 0.3em;
-}
-
-.contact-form input,
-.contact-form textarea {
-    padding: 0.8em;
-    border: none;
-    border-radius: 5px;
-    font-size: 1em;
-    font-family: Arial, sans-serif;
-    background-color: #ffffff;
-    color: #1f1f52;
-    box-shadow: 0 0 5px rgba(0,0,0,0.1);
-}
-
-.contact-form textarea {
-    resize: vertical;
-    min-height: 150px;
-}
-
-.contact-form button {
-    background-color: #2d2d7b;
-    color: #ffffff;
-    border: none;
-    padding: 0.8em 1.2em;
-    border-radius: 5px;
-    font-size: 1em;
-    cursor: pointer;
-    transition: background 0.3s ease;
-    align-self: flex-start;
-}
-
-.contact-form button:hover {
-    background-color: #1f1f52;
-}
-
+/* ── Hero banner ──────────────────────────────────── */
 .hero {
     width: 100%;
     max-width: 100vw;
-    height: 85vh;
+    height: 55vh;
+    min-height: 260px;
     background-image: var(--bg-image);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    overflow: hidden;
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-image 1s ease-in-out;
 }
-
-
 .hero-text {
-    background-color: rgba(31, 31, 82, 0.6);
-    padding: 2em;
+    background-color: rgba(31, 31, 82, 0.65);
+    padding: 2em 2.5em;
     border-radius: 10px;
     max-width: 90%;
-    /* text-align: center; */
+    width: 640px;
     color: white;
-    box-shadow: 0 0 10px rgba(0,0,0,0.3);
+    box-shadow: 0 0 14px rgba(0,0,0,0.35);
+    text-align: center;
 }
-
-
-.hero-text h1 {
-    font-size: 20px;
-    margin-bottom: 0.5em;
-}
-
 .hero-text h3 {
-    font-size: 18px;
-    margin-bottom: 0.5em;
+    margin: 0 0 0.5em 0;
+    font-size: 1.8rem;
     font-weight: 800;
+    color: #f1f1ff;
 }
-
 .hero-text p {
-    font-size: 16px;
-    margin-left: 1em;
-    margin-bottom: 0.5em;
+    margin: 0;
+    font-size: 1rem;
     font-weight: 500;
-}
-
-.hero-text {
-    max-width: 900px;
-    padding: 2.25em 2.5em;
-    /* text-align: center; */
-    margin: 0 1em;
-}
-.hero-text p,
-.hero-text h3,
-.hero-text h4 {
+    line-height: 1.45;
     color: #e8e8ff;
 }
-.hero-text h3 {
-    margin-top: 1.25rem;
-    font-size: 1.1rem;
-    color: #f1f1ff;
-    font-weight: 800;
+
+/* ── Content section ──────────────────────────────── */
+.content-section {
+    background-color: #1f1f52;
+    padding: 3em 1.5em 4em;
 }
-.hero-text h4 {
-    margin-top: 0.8rem;
-    font-size: 1rem;
+.content-inner {
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+/* ── Cards grid ───────────────────────────────────── */
+.cards-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2em;
+    margin-bottom: 2em;
+}
+.card {
+    background-color: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 10px;
+    padding: 1.4em 1.6em;
+}
+.card h4 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
     color: #ffffff;
-    font-weight: 600;
-    font-weight: 800;
 }
-.hero-text p {
-    max-width: 68ch;
-    margin: 0.6rem auto;
-    line-height: 1.2;
+.card p {
+    margin: 0;
+    font-size: 0.88rem;
     font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.card strong {
+    color: #ffffff;
 }
 
-.hero-text ul {
-    display: inline-block;
-    text-align: left;
-    padding-left: 1.2rem;
-    margin: 0.6rem auto 1.2rem auto;
+/* ── Contact info block ───────────────────────────── */
+.contact-info-block {
+    background-color: rgba(45,45,123,0.5);
+    border-radius: 10px;
+    padding: 1.8em 2em;
 }
-.hero-text li {
-    margin: 0.35rem 0;
+.contact-info-block h3 {
+    margin: 0 0 1em 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.contact-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.8em 2em;
+    margin-bottom: 1.2em;
+}
+.contact-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15em;
+}
+.contact-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #8888bb;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.contact-item span:not(.contact-label),
+.contact-item a {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #e8e8ff;
+    text-decoration: none;
+    transition: color 0.15s;
+}
+.contact-item a:hover {
+    color: #ffffff;
+}
+.contact-note {
+    margin: 0;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.5;
+    color: #c0c0e8;
+    border-top: 1px solid rgba(255,255,255,0.1);
+    padding-top: 1em;
+}
+.contact-note a {
+    color: #aaaaff;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(170,170,255,0.35);
+    transition: color 0.15s, border-color 0.15s;
+}
+.contact-note a:hover {
+    color: #ffffff;
+    border-color: #ffffff;
 }
 
-.hero-text img {
-    height: 1.2em;
-    vertical-align: middle;
-    margin-left: 0.5em;
-}
-
-
+/* ── Mobile ≤ 700px ──────────────────────────────── */
 @media (max-width: 700px) {
     header {
         flex-direction: row;
@@ -238,9 +212,7 @@ nav a.active {
         padding: 0 1em;
         position: relative;
     }
-    .logo {
-        margin: 0;
-    }
+    .logo { margin: 0; }
     .menu-toggle {
         display: block;
         position: static;
@@ -254,7 +226,7 @@ nav a.active {
         top: 80px;
         left: 10%;
         width: 80%;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        box-shadow: 0 2px 10px rgba(16,15,15,0.1);
         border-radius: 0 0 10px 10px;
         transform: translateY(-30px);
         opacity: 0;
@@ -272,24 +244,42 @@ nav a.active {
         visibility: visible;
     }
     .hero {
-        height: 90vh;
+        height: 45vh;
+        min-height: 220px;
     }
-
     .hero-text {
-        padding: 1em 1em;
+        width: 88%;
+        padding: 1.2em 1.4em;
     }
-    .hero-text ul {
-        display: block;
-        padding-left: 1.2rem;
-        max-width: none;
+    .hero-text h3 { font-size: 1.4rem; }
+    .hero-text p  { font-size: 0.9rem; }
+    .cards-grid {
+        grid-template-columns: 1fr;
     }
-
-    .hero-text h1 {
-        font-size: 2em;
+    .contact-grid {
+        grid-template-columns: 1fr;
     }
-
-    .hero-text p {
-        font-size: 1em;
+    .content-section {
+        padding: 2em 1em 3em;
+    }
+    .contact-info-block {
+        padding: 1.4em 1.2em;
     }
 }
 
+/* ── Mobile ≤ 450px ──────────────────────────────── */
+@media (max-width: 450px) {
+    .hero {
+        height: auto;
+        min-height: 200px;
+        padding: 2em 0;
+    }
+    .hero-text {
+        width: 92%;
+        padding: 1em;
+    }
+    .hero-text h3 { font-size: 1.2rem; }
+    .hero-text p  { font-size: 0.85rem; }
+    .card { padding: 1em 1.1em; }
+    .contact-info-block { padding: 1em; }
+}

--- a/styles/consumer.css
+++ b/styles/consumer.css
@@ -16,36 +16,12 @@ header {
     text-align: left;
     position: relative;
 }
-main {
-    max-width: 800px;
-    margin: 2em auto;
-    padding: 1em;
-    background-color: #67649662;
-    border-radius: 5px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-.post {
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-    color: #ffffff;
-}
-.post:last-child {
-    border-bottom: none;
-}
-.date {
-    color: #ffffff;
-    font-size: 0.9em;
-    margin-top: -0.5em;
-    margin-bottom: 1em;
-}
 .logo {
     width: 50px;
     border-radius: 5%;
     margin: 0;
     display: block;
 }
-
 .menu-toggle {
     display: none;
     background: none;
@@ -68,7 +44,6 @@ nav {
     transform: none;
     transition: none;
 }
-
 nav a {
     color: #2d2d7b;
     text-decoration: none;
@@ -77,9 +52,8 @@ nav a {
     padding: 0.3em 0.7em;
     border-radius: 5px;
     transition: background 0.2s, color 0.2s;
-    font-family: Arial, sans-serif; 
+    font-family: Arial, sans-serif;
 }
-
 nav a:hover,
 nav a:focus,
 nav a.active {
@@ -88,139 +62,155 @@ nav a.active {
     text-decoration: none;
 }
 
-.contact-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    margin-top: 1em;
-}
-
-.contact-form label {
-    color: #ffffff;
-    font-weight: bold;
-    margin-bottom: 0.3em;
-}
-
-.contact-form input,
-.contact-form textarea {
-    padding: 0.8em;
-    border: none;
-    border-radius: 5px;
-    font-size: 1em;
-    font-family: Arial, sans-serif;
-    background-color: #ffffff;
-    color: #1f1f52;
-    box-shadow: 0 0 5px rgba(0,0,0,0.1);
-}
-
-.contact-form textarea {
-    resize: vertical;
-    min-height: 150px;
-}
-
-.contact-form button {
-    background-color: #2d2d7b;
-    color: #ffffff;
-    border: none;
-    padding: 0.8em 1.2em;
-    border-radius: 5px;
-    font-size: 1em;
-    cursor: pointer;
-    transition: background 0.3s ease;
-    align-self: flex-start;
-}
-
-.contact-form button:hover {
-    background-color: #1f1f52;
-}
-
+/* ── Hero banner ──────────────────────────────────── */
 .hero {
     width: 100%;
     max-width: 100vw;
-    height: 85vh;
+    height: 55vh;
+    min-height: 260px;
     background-image: var(--bg-image);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    overflow: hidden;
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-image 1s ease-in-out;
 }
-
-
 .hero-text {
-    background-color: rgba(31, 31, 82, 0.6);
-    padding: 2em;
+    background-color: rgba(31, 31, 82, 0.65);
+    padding: 2em 2.5em;
     border-radius: 10px;
     max-width: 90%;
-    width: 600px;
+    width: 640px;
     color: white;
-    box-shadow: 0 0 10px rgba(0,0,0,0.3);
-}
-
-
-.hero-text h1 {
-    font-size: 20px;
-    margin-bottom: 0.5em;
-    font-weight: 800;
-}
-
-.hero-text h3 {
-    font-size: 18px;
-    margin-bottom: 0.5em;
-    font-weight: 800;
-}
-
-.hero-text p {
-    font-size: 16px;
-    margin-bottom: 0.5em;
-    font-weight: 500;
-}
-
-
-.hero-text p,
-.hero-text h3,
-.hero-text h4 {
-    color: #e8e8ff;
+    box-shadow: 0 0 14px rgba(0,0,0,0.35);
+    text-align: center;
 }
 .hero-text h3 {
-    margin-top: 1.25rem;
+    margin: 0 0 0.5em 0;
+    font-size: 1.8rem;
     font-weight: 800;
     color: #f1f1ff;
 }
-.hero-text h4 {
-    margin-top: 0.8rem;
-    font-size: 1rem;
-    color: #ffffff;
-    font-weight: 800;
-}
 .hero-text p {
-    font-size: 0.9rem;
-    max-width: 68ch;
+    margin: 0;
+    font-size: 1rem;
     font-weight: 500;
-    line-height: 1.3;
+    line-height: 1.45;
+    color: #e8e8ff;
 }
 
-.hero-text ul {
+/* ── Content section ──────────────────────────────── */
+.content-section {
+    background-color: #1f1f52;
+    padding: 3em 1.5em 4em;
+}
+.content-inner {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.section-title {
+    color: #f1f1ff;
+    font-size: 1.5rem;
+    font-weight: 800;
+    margin: 0 0 1.5em 0;
+    text-align: center;
+    letter-spacing: 0.02em;
+}
+
+/* ── Cards grid ───────────────────────────────────── */
+.cards-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2em;
+    margin-bottom: 2.5em;
+}
+.card {
+    background-color: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 10px;
+    padding: 1.4em 1.6em;
+}
+.card h4 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #ffffff;
+}
+.card p {
+    margin: 0;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+
+/* ── Info block ───────────────────────────────────── */
+.info-block {
+    background-color: rgba(255,255,255,0.05);
+    border-left: 4px solid #4a4ab8;
+    border-radius: 0 10px 10px 0;
+    padding: 1.2em 1.6em;
+    margin-bottom: 1.2em;
+}
+.info-block h3 {
+    margin: 0 0 0.5em 0;
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.info-block p {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.info-block strong {
+    color: #ffffff;
+}
+
+/* ── CTA block ────────────────────────────────────── */
+.cta-block {
+    background-color: rgba(45,45,123,0.5);
+    border-radius: 10px;
+    padding: 1.6em 2em;
+    text-align: center;
+    margin-top: 1.8em;
+}
+.cta-block h3 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.cta-block p {
+    margin: 0 0 1em 0;
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.5;
+    color: #d0d0f0;
+}
+.cta-link {
     display: inline-block;
-    text-align: left;
-    padding-left: 1.2rem;
-    margin: 0.6rem auto 1.2rem auto;
+    background-color: #2d2d7b;
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 0.95rem;
+    padding: 0.75em 1.6em;
+    border-radius: 7px;
+    transition: background 0.2s, transform 0.15s;
 }
-.hero-text li {
-    margin: 0.35rem 0;
+.cta-link:hover,
+.cta-link:focus {
+    background-color: #3d3da0;
+    transform: translateY(-2px);
+    outline: none;
 }
 
-.hero-text img {
-    height: 1.2em;
-    vertical-align: middle;
-    margin-left: 0.5em;
-}
-
-
+/* ── Mobile ≤ 700px ──────────────────────────────── */
 @media (max-width: 700px) {
     header {
         flex-direction: row;
@@ -230,9 +220,7 @@ nav a.active {
         padding: 0 1em;
         position: relative;
     }
-    .logo {
-        margin: 0;
-    }
+    .logo { margin: 0; }
     .menu-toggle {
         display: block;
         position: static;
@@ -246,7 +234,7 @@ nav a.active {
         top: 80px;
         left: 10%;
         width: 80%;
-        box-shadow: 0 2px 10px rgba(16, 15, 15, 0.1);
+        box-shadow: 0 2px 10px rgba(16,15,15,0.1);
         border-radius: 0 0 10px 10px;
         transform: translateY(-30px);
         opacity: 0;
@@ -264,27 +252,39 @@ nav a.active {
         visibility: visible;
     }
     .hero {
-        height: 90vh;
+        height: 45vh;
+        min-height: 220px;
     }
-
     .hero-text {
-        width: 85%;
+        width: 88%;
+        padding: 1.2em 1.4em;
+    }
+    .hero-text h3 { font-size: 1.4rem; }
+    .hero-text p  { font-size: 0.9rem; }
+    .cards-grid {
+        grid-template-columns: 1fr;
+    }
+    .content-section {
+        padding: 2em 1em 3em;
+    }
+    .cta-block {
+        padding: 1.4em 1.2em;
+    }
+}
+
+/* ── Mobile ≤ 450px ──────────────────────────────── */
+@media (max-width: 450px) {
+    .hero {
+        height: auto;
+        min-height: 200px;
+        padding: 2em 0;
+    }
+    .hero-text {
+        width: 92%;
         padding: 1em;
     }
-
-    .hero-text h1 {
-        font-size: 2em;
-    }
-
-    .hero-text h3 {
-        font-size: 1.3em;
-    }
-
-    .hero-text h4 {
-        font-size: 1em;
-    }
-
-    .hero-text p {
-        font-size: 1em;
-    }
+    .hero-text h3 { font-size: 1.2rem; }
+    .hero-text p  { font-size: 0.85rem; }
+    .card { padding: 1em 1.1em; }
+    .info-block, .cta-block { padding: 1em; }
 }

--- a/styles/devices.css
+++ b/styles/devices.css
@@ -16,36 +16,12 @@ header {
     text-align: left;
     position: relative;
 }
-main {
-    max-width: 800px;
-    margin: 2em auto;
-    padding: 1em;
-    background-color: #67649662;
-    border-radius: 5px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-.post {
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-    color: #ffffff;
-}
-.post:last-child {
-    border-bottom: none;
-}
-.date {
-    color: #ffffff;
-    font-size: 0.9em;
-    margin-top: -0.5em;
-    margin-bottom: 1em;
-}
 .logo {
     width: 50px;
     border-radius: 5%;
     margin: 0;
     display: block;
 }
-
 .menu-toggle {
     display: none;
     background: none;
@@ -68,7 +44,6 @@ nav {
     transform: none;
     transition: none;
 }
-
 nav a {
     color: #2d2d7b;
     text-decoration: none;
@@ -77,9 +52,8 @@ nav a {
     padding: 0.3em 0.7em;
     border-radius: 5px;
     transition: background 0.2s, color 0.2s;
-    font-family: Arial, sans-serif; 
+    font-family: Arial, sans-serif;
 }
-
 nav a:hover,
 nav a:focus,
 nav a.active {
@@ -88,140 +62,155 @@ nav a.active {
     text-decoration: none;
 }
 
-.contact-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    margin-top: 1em;
-}
-
-.contact-form label {
-    color: #ffffff;
-    font-weight: bold;
-    margin-bottom: 0.3em;
-}
-
-.contact-form input,
-.contact-form textarea {
-    padding: 0.8em;
-    border: none;
-    border-radius: 5px;
-    font-size: 1em;
-    font-family: Arial, sans-serif;
-    background-color: #ffffff;
-    color: #1f1f52;
-    box-shadow: 0 0 5px rgba(0,0,0,0.1);
-}
-
-.contact-form textarea {
-    resize: vertical;
-    min-height: 150px;
-}
-
-.contact-form button {
-    background-color: #2d2d7b;
-    color: #ffffff;
-    border: none;
-    padding: 0.8em 1.2em;
-    border-radius: 5px;
-    font-size: 1em;
-    cursor: pointer;
-    transition: background 0.3s ease;
-    align-self: flex-start;
-}
-
-.contact-form button:hover {
-    background-color: #1f1f52;
-}
-
+/* ── Hero banner ──────────────────────────────────── */
 .hero {
     width: 100%;
     max-width: 100vw;
-    height: 85vh;
+    height: 55vh;
+    min-height: 260px;
     background-image: var(--bg-image);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    overflow: hidden;
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-image 1s ease-in-out;
 }
-
-
 .hero-text {
-    background-color: rgba(31, 31, 82, 0.6);
-    padding: 2em;
-    width: 800px;
+    background-color: rgba(31, 31, 82, 0.65);
+    padding: 2em 2.5em;
     border-radius: 10px;
-    max-width: 80%;
+    max-width: 90%;
+    width: 640px;
     color: white;
-    box-shadow: 0 0 10px rgba(0,0,0,0.3);
-}
-
-
-.hero-text h1 {
-    font-size: 20px;
-    margin-bottom: 0.5em;
-    font-weight: 800;
-}
-
-.hero-text h3 {
-    font-size: 18px;
-    margin-bottom: 0.5em;
-    font-weight: 800;
-}
-
-.hero-text p {
-    font-size: 16px;
-    margin-left: 1em;
-    margin-bottom: 0.5em;
-    font-weight: 500;
-}
-
-
-.hero-text p,
-.hero-text h3,
-.hero-text h4 {
-    color: #e8e8ff;
+    box-shadow: 0 0 14px rgba(0,0,0,0.35);
+    text-align: center;
 }
 .hero-text h3 {
-    margin-top: 1.25rem;
-    font-size: 1.4rem;
+    margin: 0 0 0.5em 0;
+    font-size: 1.8rem;
+    font-weight: 800;
     color: #f1f1ff;
 }
-.hero-text h4 {
-    margin-top: 0.8rem;
-    font-size: 1rem;
-    color: #ffffff;
-    font-weight: 800;
-    line-height: 1.3;
-}
 .hero-text p {
-    font-size: 0.9rem;
-    max-width: 68ch;
-    line-height: 1.3;
+    margin: 0;
+    font-size: 1rem;
     font-weight: 500;
+    line-height: 1.45;
+    color: #e8e8ff;
 }
 
-.hero-text ul {
+/* ── Content section ──────────────────────────────── */
+.content-section {
+    background-color: #1f1f52;
+    padding: 3em 1.5em 4em;
+}
+.content-inner {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.section-title {
+    color: #f1f1ff;
+    font-size: 1.5rem;
+    font-weight: 800;
+    margin: 0 0 1.5em 0;
+    text-align: center;
+    letter-spacing: 0.02em;
+}
+
+/* ── Cards grid ───────────────────────────────────── */
+.cards-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2em;
+    margin-bottom: 2.5em;
+}
+.card {
+    background-color: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 10px;
+    padding: 1.4em 1.6em;
+}
+.card h4 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #ffffff;
+}
+.card p {
+    margin: 0;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+
+/* ── Info blocks ──────────────────────────────────── */
+.info-block {
+    background-color: rgba(255,255,255,0.05);
+    border-left: 4px solid #4a4ab8;
+    border-radius: 0 10px 10px 0;
+    padding: 1.2em 1.6em;
+    margin-bottom: 1.2em;
+}
+.info-block h3 {
+    margin: 0 0 0.5em 0;
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.info-block p {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #c8c8ee;
+}
+.info-block strong {
+    color: #ffffff;
+}
+
+/* ── CTA block ────────────────────────────────────── */
+.cta-block {
+    background-color: rgba(45,45,123,0.5);
+    border-radius: 10px;
+    padding: 1.6em 2em;
+    text-align: center;
+    margin-top: 1.8em;
+}
+.cta-block h3 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.cta-block p {
+    margin: 0 0 1em 0;
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.5;
+    color: #d0d0f0;
+}
+.cta-link {
     display: inline-block;
-    text-align: left;
-    padding-left: 1.2rem;
-    margin: 0.6rem auto 1.2rem auto;
+    background-color: #2d2d7b;
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 0.95rem;
+    padding: 0.75em 1.6em;
+    border-radius: 7px;
+    transition: background 0.2s, transform 0.15s;
 }
-.hero-text li {
-    margin: 0.35rem 0;
+.cta-link:hover,
+.cta-link:focus {
+    background-color: #3d3da0;
+    transform: translateY(-2px);
+    outline: none;
 }
 
-.hero-text img {
-    height: 1.2em;
-    vertical-align: middle;
-    margin-left: 0.5em;
-}
-
+/* ── Mobile ≤ 700px ──────────────────────────────── */
 @media (max-width: 700px) {
     header {
         flex-direction: row;
@@ -231,9 +220,7 @@ nav a.active {
         padding: 0 1em;
         position: relative;
     }
-    .logo {
-        margin: 0;
-    }
+    .logo { margin: 0; }
     .menu-toggle {
         display: block;
         position: static;
@@ -247,7 +234,7 @@ nav a.active {
         top: 80px;
         left: 10%;
         width: 80%;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        box-shadow: 0 2px 10px rgba(16,15,15,0.1);
         border-radius: 0 0 10px 10px;
         transform: translateY(-30px);
         opacity: 0;
@@ -265,122 +252,39 @@ nav a.active {
         visibility: visible;
     }
     .hero {
-        height: 92vh;
+        height: 45vh;
+        min-height: 220px;
     }
-
     .hero-text {
-        width: 85%;
-        padding: 1em;
+        width: 88%;
+        padding: 1.2em 1.4em;
     }
-    .hero-text ul {
-        display: block;
-        padding-left: 1.2rem;
-        max-width: none;
+    .hero-text h3 { font-size: 1.4rem; }
+    .hero-text p  { font-size: 0.9rem; }
+    .cards-grid {
+        grid-template-columns: 1fr;
     }
-
-    .hero-text h3 {
-        font-size: 1.3em;
+    .content-section {
+        padding: 2em 1em 3em;
     }
-
-    .hero-text h4 {
-        font-size: 1em;
-    }
-
-    .hero-text p {
-        font-size: 0.88em;
+    .cta-block {
+        padding: 1.4em 1.2em;
     }
 }
+
+/* ── Mobile ≤ 450px ──────────────────────────────── */
 @media (max-width: 450px) {
     .hero {
-        min-height: 100vh;
         height: auto;
+        min-height: 200px;
         padding: 2em 0;
     }
     .hero-text {
-        width: 95%;
-        padding: 1em 0.8em;
-        margin: 1em auto;
+        width: 92%;
+        padding: 1em;
     }
-
-    .hero-text h1 {
-        font-size: 1.3em;
-        margin-bottom: 0.6em;
-    }
-
-    .hero-text h3 {
-        font-size: 1em;
-        margin-top: 0.8em;
-        margin-bottom: 0.5em;
-    }
-
-    .hero-text h4 {
-        font-size: 0.9em;
-        margin-top: 0.5em;
-        margin-bottom: 0.3em;
-    }
-
-    .hero-text p {
-        font-size: 0.8em;
-        line-height: 1.3;
-        margin-bottom: 0.4em;
-    }
-
-    .hero-text ul {
-        padding-left: 1rem;
-        margin: 0.4rem 0;
-    }
-
-    .hero-text li {
-        margin: 0.2rem 0;
-        font-size: 0.85em;
-    }
+    .hero-text h3 { font-size: 1.2rem; }
+    .hero-text p  { font-size: 0.85rem; }
+    .card { padding: 1em 1.1em; }
+    .info-block, .cta-block { padding: 1em; }
 }
-
-@media (max-width: 390px) {
-    .hero {
-        min-height: 110vh;
-        height: auto;
-        padding: 1.5em 0 3em 0;
-        align-items: flex-start;
-    }
-    
-    .hero-text {
-        width: 96%;
-        padding: 0.8em 0.6em;
-        margin: 0.5em auto;
-    }
-
-    .hero-text h1 {
-        font-size: 1.2em;
-        margin-bottom: 0.5em;
-    }
-
-    .hero-text h3 {
-        font-size: 0.95em;
-        margin-top: 0.6em;
-        margin-bottom: 0.4em;
-    }
-
-    .hero-text h4 {
-        font-size: 0.85em;
-        margin-top: 0.4em;
-        margin-bottom: 0.3em;
-    }
-
-    .hero-text p {
-        font-size: 0.75em;
-        line-height: 1.25;
-        margin-bottom: 0.4em;
-    }
-
-    .hero-text ul {
-        padding-left: 0.8rem;
-        margin: 0.3rem 0;
-    }
-
-    .hero-text li {
-        margin: 0.15rem 0;
-        font-size: 0.8em;
-    }
-}
-

--- a/styles/privacy.css
+++ b/styles/privacy.css
@@ -1,0 +1,177 @@
+@import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@500;700&display=swap');
+
+body {
+    font-family: "League Spartan", sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #1f1f52;
+}
+header {
+    background-color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0 2em;
+    height: 80px;
+    text-align: left;
+    position: relative;
+}
+.logo {
+    width: 50px;
+    border-radius: 5%;
+    margin: 0;
+    display: block;
+}
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 2em;
+    position: absolute;
+    right: 1em;
+    top: 1.5em;
+    cursor: pointer;
+    z-index: 10;
+}
+nav {
+    display: flex;
+    gap: 1em;
+    align-items: center;
+    margin: 0 auto;
+    justify-content: flex-end;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+    transition: none;
+}
+nav a {
+    color: #2d2d7b;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 1.1em;
+    padding: 0.3em 0.7em;
+    border-radius: 5px;
+    transition: background 0.2s, color 0.2s;
+    font-family: Arial, sans-serif;
+}
+nav a:hover,
+nav a:focus,
+nav a.active {
+    background: #2d2d7b;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* ── Privacy content ──────────────────────────────── */
+.privacy-section {
+    padding: 3em 1.5em 4em;
+}
+.privacy-inner {
+    max-width: 780px;
+    margin: 0 auto;
+    background-color: rgba(255,255,255,0.05);
+    border-radius: 12px;
+    padding: 2.5em 3em;
+}
+.privacy-inner h1 {
+    margin: 0 0 0.2em 0;
+    font-size: 1.8rem;
+    font-weight: 800;
+    color: #f1f1ff;
+}
+.updated {
+    font-size: 0.82rem;
+    color: #7878aa;
+    margin: 0 0 2em 0;
+}
+.privacy-inner h2 {
+    margin: 1.8em 0 0.5em 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #d0d0ff;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+    padding-bottom: 0.3em;
+}
+.privacy-inner p {
+    margin: 0 0 0.8em 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.6;
+    color: #c0c0e8;
+}
+.privacy-inner ul {
+    margin: 0.4em 0 0.8em 0;
+    padding-left: 1.4em;
+}
+.privacy-inner li {
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.6;
+    color: #c0c0e8;
+    margin-bottom: 0.3em;
+}
+.privacy-inner strong {
+    color: #e8e8ff;
+}
+.privacy-inner a {
+    color: #aaaaff;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(170,170,255,0.35);
+    transition: color 0.15s, border-color 0.15s;
+}
+.privacy-inner a:hover {
+    color: #ffffff;
+    border-color: #ffffff;
+}
+
+/* ── Mobile ≤ 700px ──────────────────────────────── */
+@media (max-width: 700px) {
+    header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        height: 80px;
+        padding: 0 1em;
+        position: relative;
+    }
+    .logo { margin: 0; }
+    .menu-toggle {
+        display: block;
+        position: static;
+        margin-left: auto;
+        z-index: 30;
+    }
+    nav {
+        flex-direction: column;
+        background: #fff;
+        position: absolute;
+        top: 80px;
+        left: 10%;
+        width: 80%;
+        box-shadow: 0 2px 10px rgba(16,15,15,0.1);
+        border-radius: 0 0 10px 10px;
+        transform: translateY(-30px);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.3s cubic-bezier(.4,2,.6,1), opacity 0.3s;
+        z-index: 20;
+        margin: 0;
+        display: flex;
+        visibility: hidden;
+    }
+    nav.open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+        visibility: visible;
+    }
+    .privacy-section {
+        padding: 2em 1em 3em;
+    }
+    .privacy-inner {
+        padding: 1.5em 1.2em;
+    }
+    .privacy-inner h1 {
+        font-size: 1.4rem;
+    }
+}


### PR DESCRIPTION
## Summary

- **Laitteet** – restructured from a single text block to: short hero banner + 6 product category cards (2-column grid) + 2 info blocks (käyttöönotto, hankintavaihtoehdot) + CTA
- **Kuluttajat** – same treatment: short hero + 4 service cards (pelikoneet, peruskäyttö, käytetyt laitteet, oheislaitteet) + info block + CTA
- **privacy.html** – new tietosuojaseloste page in Finnish covering all GDPR requirements: data controller, purpose, retention period, Web3Forms as third-party processor, cookie policy (none used), and all 6 user rights
- **Footer** – "Tietosuojaseloste" link added to the footer bottom bar on all pages
- Both pages share the same visual language as the software development page (dark cards, left-bordered info blocks, navy CTA block)

## Test plan

- [ ] Check Laitteet page — 6 cards render in 2 columns on desktop, 1 column on mobile
- [ ] Check Kuluttajat page — 4 cards render correctly
- [ ] Open privacy.html — all 11 sections readable, links to email/phone work
- [ ] Verify "Tietosuojaseloste" link in footer on every page points to privacy.html
- [ ] Resize to mobile — hero shrinks, cards stack, nav hamburger works

🤖 Generated with [Claude Code](https://claude.com/claude-code)