### PR TITLE
Add custom AI agents and local LLM PC to software development page

### DIFF
--- a/softwaredevelopment.html
+++ b/softwaredevelopment.html
@@ -68,6 +68,28 @@
 				</div>
 
 				<div class="service-card">
+					<h4>Mukautetut AI-agentit</h4>
+					<p>Rakennamme teille räätälöityjä tekoälyagentteja, jotka toimivat juuri teidän prosessienne mukaisesti. Kuvailette mitä haluatte – me lisäämme tarvittavat työkalut ja integroimme agentin osaksi teidän järjestelmiänne:</p>
+					<ul>
+						<li>Agentit, jotka lukevat ja kirjoittavat tietokantoja tai tiedostoja</li>
+						<li>Agentit, jotka käyttävät ulkoisia API-rajapintoja automaattisesti</li>
+						<li>Monivaiheinen päätöksenteko ilman ihmisen väliintuloa</li>
+						<li>Agentti omaan sisäiseen tietokantaanne tai dokumenttiarkistoonne</li>
+					</ul>
+				</div>
+
+				<div class="service-card">
+					<h4>Paikallinen LLM-tietokone</h4>
+					<p>Myymme valmiiksi rakennettuja tietokoneita, joihin on asennettu paikallinen kielimalli (LLM) – plug &amp; play, ilman pilviriippuvuuksia. Kaikki data pysyy teidän verkossanne:</p>
+					<ul>
+						<li>Valmis laite omaan tilaanne – kytke kiinni, käytä heti</li>
+						<li>Kaikki saman verkon käyttäjät voivat hyödyntää samaa mallia ja omaa dataa</li>
+						<li>Ei pilvitallennusta, ei tietovuotoriskiä – data ei koskaan poistu verkostanne</li>
+						<li>Sopii yrityksille, joilla on tiukat tietosuoja- tai tietoturvavaatimukset</li>
+					</ul>
+				</div>
+
+				<div class="service-card">
 					<h4>Automaatio &amp; CI/CD</h4>
 					<p>Automatisoimme ohjelmistojen testauksen ja julkaisun CI/CD-putkilinjoilla. Muutokset kulkevat kehitysympäristöstä tuotantoon hallitusti, nopeasti ja luotettavasti ilman manuaalista työtä.</p>
 				</div>


### PR DESCRIPTION
## Summary
- Added **Mukautetut AI-agentit** card — customers describe their needs, we build the agent with the right tools (DB/file access, external APIs, multi-step automation, internal knowledge bases)
- Added **Paikallinen LLM-tietokone** card — plug-and-play PC with local LLM, shared across the same network, no cloud, no data leaves the customer's network

## Test plan
- [ ] Open `softwaredevelopment.html` in browser and verify both new cards render correctly in the services grid
- [ ] Check mobile layout (responsive)
- [ ] Verify no existing cards are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)